### PR TITLE
Replace useSyncExternalStore with useState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.20.2",
       "license": "MIT",
       "dependencies": {
-        "range-at-index": "^1.0.4",
-        "use-sync-external-store": "^1.2.0"
+        "range-at-index": "^1.0.4"
       },
       "devDependencies": {
         "@babel/plugin-transform-react-pure-annotations": "7.18.6",
@@ -27,7 +26,6 @@
         "@types/node-emoji": "1.8.2",
         "@types/react": "18.2.6",
         "@types/react-highlight-words": "0.16.4",
-        "@types/use-sync-external-store": "0.0.3",
         "assert": "2.0.0",
         "concurrently": "8.0.1",
         "esbuild": "0.17.18",
@@ -7652,12 +7650,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "node_modules/@types/wait-on": {
@@ -23877,14 +23869,6 @@
         "react-dom": "16.8.0 - 18"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -30293,12 +30277,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
-    },
-    "@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
       "dev": true
     },
     "@types/wait-on": {
@@ -42527,11 +42505,6 @@
       "requires": {
         "@juggle/resize-observer": "^3.3.1"
       }
-    },
-    "use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "prepublishOnly": "npm run typedoc && rimraf lib && npm run build"
   },
   "dependencies": {
-    "range-at-index": "^1.0.4",
-    "use-sync-external-store": "^1.2.0"
+    "range-at-index": "^1.0.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-pure-annotations": "7.18.6",
@@ -38,7 +37,6 @@
     "@types/node-emoji": "1.8.2",
     "@types/react": "18.2.6",
     "@types/react-highlight-words": "0.16.4",
-    "@types/use-sync-external-store": "0.0.3",
     "assert": "2.0.0",
     "concurrently": "8.0.1",
     "esbuild": "0.17.18",

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,23 +1,26 @@
 import { refKey } from "./utils";
 
+export type SelectionRange = [number | null, number | null];
+
 export const initSelectionStore = (
-  ref: React.RefObject<HTMLTextAreaElement | HTMLInputElement>
+  ref: React.RefObject<HTMLTextAreaElement | HTMLInputElement>,
+  onSelectionUpdate: (range: SelectionRange) => void
 ) => {
-  const subscribers = new Set<() => void>();
   let cache: [number | null, number | null] = [null, null];
   let compositionEvent: CompositionEvent | void;
+  const _getSelection = (): [number | null, number | null] => {
+    const selectionStart = handle._getSelectionStart();
+    const selectionEnd = handle._getSelectionEnd();
+    if (cache[0] === selectionStart && cache[1] === selectionEnd) {
+      return cache;
+    }
+    cache = [selectionStart, selectionEnd];
+    return cache;
+  };
   const handle = {
-    _subscribe(cb: () => void) {
-      subscribers.add(cb);
-      return () => {
-        subscribers.delete(cb);
-      };
-    },
     _updateSeletion() {
       setTimeout(() => {
-        subscribers.forEach((cb) => {
-          cb();
-        });
+        onSelectionUpdate(_getSelection());
       });
     },
     _setComposition(event: CompositionEvent | void) {
@@ -42,15 +45,6 @@ export const initSelectionStore = (
         pos = Math.min(pos, el.selectionStart! + compositionEvent.data.length);
       }
       return pos;
-    },
-    _getSelection(): [number | null, number | null] {
-      const selectionStart = handle._getSelectionStart();
-      const selectionEnd = handle._getSelectionEnd();
-      if (cache[0] === selectionStart && cache[1] === selectionEnd) {
-        return cache;
-      }
-      cache = [selectionStart, selectionEnd];
-      return cache;
     },
   };
   return handle;

--- a/src/textarea.tsx
+++ b/src/textarea.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import { useSyncExternalStore } from "use-sync-external-store/shim/index.js";
 // @ts-expect-error no type definition
 import rangeAtIndex from "range-at-index";
 import {
@@ -22,7 +21,7 @@ import {
   stopPropagation,
   syncBackdropStyle,
 } from "./dom";
-import { initSelectionStore } from "./selection";
+import { SelectionRange, initSelectionStore } from "./selection";
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 import type { CaretPosition, Renderer } from "./types";
 import { refKey } from "./utils";
@@ -118,11 +117,10 @@ export const RichTextarea = forwardRef<RichTextareaHandle, RichTextareaProps>(
     const caretColorRef = useRef("");
     const pointedRef = useRef<HTMLElement | null>(null);
 
-    const selectionStore = useStatic(() => initSelectionStore(textAreaRef));
-    const [selectionStart, selectionEnd] = useSyncExternalStore(
-      selectionStore._subscribe,
-      selectionStore._getSelection,
-      selectionStore._getSelection
+    const [[selectionStart, selectionEnd], setSelection] =
+      useState<SelectionRange>([null, null]);
+    const selectionStore = useStatic(() =>
+      initSelectionStore(textAreaRef, setSelection)
     );
 
     const totalWidth = width + hPadding;


### PR DESCRIPTION
useState seems to be enough for usage in rich-textarea, that has store by component and has no possibility of tearing.
So I remove it for smaller bundle size and controllability.