### PR TITLE
Change setSelectionRange behavior to be the same as native

### DIFF
--- a/src/input.tsx
+++ b/src/input.tsx
@@ -91,7 +91,6 @@ const Backdrop = memo(
  * | ----------------- | -------- | ---------------------------------------------------------------------- |
  * | selectionStart    | `number` | Same as original but has handling of composition event                    |
  * | selectionEnd      | `number` | Same as original but has handling of composition event                    |
- * | setSelectionRange |          | Same as original but with focus                                           |
  * | setRangeText      |          | Same as original but has fallback to `document.execCommand("insertText")` |
  */
 export interface RichInputHandle extends HTMLInputElement {}
@@ -203,12 +202,6 @@ export const RichInput = forwardRef<RichInputHandle, RichInputProps>(
             } else {
               return sel;
             }
-          },
-          setSelectionRange(
-            ...args: Parameters<HTMLInputElement["setSelectionRange"]>
-          ) {
-            el.focus();
-            el.setSelectionRange(...args);
           },
           setRangeText(
             text: string,

--- a/src/textarea.tsx
+++ b/src/textarea.tsx
@@ -81,7 +81,6 @@ const Backdrop = memo(
  * | ----------------- | -------- | ------------------------------------------------------------------------- |
  * | selectionStart    | `number` | Same as original but has handling of composition event                    |
  * | selectionEnd      | `number` | Same as original but has handling of composition event                    |
- * | setSelectionRange |          | Same as original but with focus                                           |
  * | setRangeText      |          | Same as original but has fallback to `document.execCommand("insertText")` |
  */
 export interface RichTextareaHandle extends HTMLTextAreaElement {}
@@ -181,12 +180,6 @@ export const RichTextarea = forwardRef<RichTextareaHandle, RichTextareaProps>(
             } else {
               return sel;
             }
-          },
-          setSelectionRange(
-            ...args: Parameters<HTMLTextAreaElement["setSelectionRange"]>
-          ) {
-            el.focus();
-            el.setSelectionRange(...args);
           },
           setRangeText(
             text: string,


### PR DESCRIPTION
You can reproduce the previous behavior just call `focus` before `setSelectionRange`.