### PR TITLE
Fix: using RichInput on SSR throws "navigator is not defined" error

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -4,6 +4,9 @@ import { refKey } from "./utils";
  * @internal
  */
 export const isSafari = (): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
   const ua = navigator.userAgent.toLowerCase();
   return ua.indexOf("safari") > -1 && ua.indexOf("chrome") <= -1;
 };


### PR DESCRIPTION
## Summary
Make `isSafari()` return `false` when navigator is not defined.

## Context
Rendering `experimental_RichInput` on server-side throws an error of `navigator is not defined` because `isSafari()` directly uses `navigator` without checking if it's defined.
I understand the component is experimental, but I want it to work with Next.js SSR.
