### PR TITLE
Optional custom functions for regex renderer

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -102,9 +102,9 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `matchers` | [regex: RegExp, style: string][] |
+| Name       | Type                            |
+| :--------- | :------------------------------ | -------------------------------------------------------------- |
+| `matchers` | ([regex: RegExp, style: string] | [regex: RegExp, style: string, fn?: (_: string) => boolean])[] |
 
 #### Returns
 

--- a/src/renderers/regex/index.tsx
+++ b/src/renderers/regex/index.tsx
@@ -17,14 +17,14 @@ export type StyleOrRender =
  * The priority is descending order.
  */
 export const createRegexRenderer = (
-  matchers: [regex: RegExp, style: StyleOrRender][]
+  matchers: ([regex: RegExp, style: StyleOrRender] | [regex: RegExp, style: StyleOrRender, fn?: (_: string) => boolean])[],
 ): Renderer => {
   const allStyles = matchers.map(([, style]) => style);
 
   return (value) => {
     const [indexSet, startToStyleMap, endToStyleMap] = matchers.reduce(
-      (acc, [matcher, style]) => {
-        execReg(matcher, value).forEach((m) => {
+      (acc, [matcher, style, fn]) => {
+        execReg(matcher, value, fn).forEach((m) => {
           const start = m.index;
           const end = m.index + m[0]!.length;
 

--- a/src/renderers/regex/index.tsx
+++ b/src/renderers/regex/index.tsx
@@ -17,14 +17,21 @@ export type StyleOrRender =
  * The priority is descending order.
  */
 export const createRegexRenderer = (
-  matchers: ([regex: RegExp, style: StyleOrRender] | [regex: RegExp, style: StyleOrRender, fn?: (_: string) => boolean])[],
+  matchers: (
+    | [regex: RegExp, style: StyleOrRender]
+    | [
+        regex: RegExp,
+        style: StyleOrRender,
+        shouldRender?: (matchedText: string) => boolean,
+      ]
+  )[]
 ): Renderer => {
   const allStyles = matchers.map(([, style]) => style);
 
   return (value) => {
     const [indexSet, startToStyleMap, endToStyleMap] = matchers.reduce(
-      (acc, [matcher, style, fn]) => {
-        execReg(matcher, value, fn).forEach((m) => {
+      (acc, [matcher, style, shouldRender]) => {
+        execReg(matcher, value, shouldRender).forEach((m) => {
           const start = m.index;
           const end = m.index + m[0]!.length;
 

--- a/src/renderers/regex/utils.ts
+++ b/src/renderers/regex/utils.ts
@@ -1,11 +1,15 @@
 /**
  * @internal
  */
-export const execReg = (reg: RegExp, text: string, fn?: (_: string) => boolean): RegExpExecArray[] => {
+export const execReg = (
+  reg: RegExp,
+  text: string,
+  shouldRender?: (matchedText: string) => boolean
+): RegExpExecArray[] => {
   const results: RegExpExecArray[] = [];
   let match: RegExpExecArray | null = null;
   while ((match = reg.exec(text))) {
-    if (fn && !fn(text)) {
+    if (shouldRender && !shouldRender(text)) {
       continue;
     }
     results.push(match);

--- a/src/renderers/regex/utils.ts
+++ b/src/renderers/regex/utils.ts
@@ -1,10 +1,13 @@
 /**
  * @internal
  */
-export const execReg = (reg: RegExp, text: string): RegExpExecArray[] => {
+export const execReg = (reg: RegExp, text: string, fn?: (_: string) => boolean): RegExpExecArray[] => {
   const results: RegExpExecArray[] = [];
   let match: RegExpExecArray | null = null;
   while ((match = reg.exec(text))) {
+    if (fn && !fn(text)) {
+      continue;
+    }
     results.push(match);
   }
   return results;


### PR DESCRIPTION
In some cases we need the ability to run custom code when rendering, more than a regex can do. This adds an optional callback function that when provided, should return `true` or `false` on the given input text `string`. It's backwards compatible with current `createRegexRenderer` usages, but allows overwriting the regex using custom code to prevent matching when necessary.