### PR TITLE
Also pass shouldRender the match result

### DIFF
--- a/src/renderers/regex/index.tsx
+++ b/src/renderers/regex/index.tsx
@@ -22,7 +22,7 @@ export const createRegexRenderer = (
     | [
         regex: RegExp,
         style: StyleOrRender,
-        shouldRender?: (matchedText: string) => boolean,
+        shouldRender?: (matchedText: string, matchResult: RegExpExecArray) => boolean,
       ]
   )[]
 ): Renderer => {
@@ -30,8 +30,8 @@ export const createRegexRenderer = (
 
   return (value) => {
     const [indexSet, startToStyleMap, endToStyleMap] = matchers.reduce(
-      (acc, [matcher, style, shouldRender]) => {
-        execReg(matcher, value, shouldRender).forEach((m) => {
+      (acc, [regex, style, shouldRender]) => {
+        execReg(regex, value, shouldRender).forEach((m) => {
           const start = m.index;
           const end = m.index + m[0]!.length;
 

--- a/src/renderers/regex/utils.ts
+++ b/src/renderers/regex/utils.ts
@@ -4,12 +4,12 @@
 export const execReg = (
   reg: RegExp,
   text: string,
-  shouldRender?: (matchedText: string) => boolean
+  shouldRender?: (matchedText: string, matchResult: RegExpExecArray) => boolean
 ): RegExpExecArray[] => {
   const results: RegExpExecArray[] = [];
   let match: RegExpExecArray | null = null;
   while ((match = reg.exec(text))) {
-    if (shouldRender && !shouldRender(text)) {
+    if (shouldRender && !shouldRender(text, match)) {
       continue;
     }
     results.push(match);


### PR DESCRIPTION
Improving on #148 by passing the matched result to the `shouldRender` callback function to make it's decision easier. Sometimes it might need access to a regex group not just the original input text.